### PR TITLE
setup.py: Add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     keywords="scruffy",
     url="https://github.com/snare/scruffy",
     packages=['scruffy'],
-    install_requires=['pyyaml', 'six'],
+    install_requires=['pyyaml', 'six', 'sqlalchemy' 'pkg-resources'],
 )


### PR DESCRIPTION
Scruffy imports from sqlalchemy and pkg_resources, but these are not listed as dependencies in setup.py.

This pull request adds the missing dependencies.